### PR TITLE
Fix `set_multicast_if` for IPv4 interfaces on UNIX

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlight"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "📡 Rust mDNS server & client library designed with user interfaces in mind"
 authors = ["William Venner <william@venner.io>"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add Searchlight to your [`Cargo.toml`](https://doc.rust-lang.org/cargo/reference
 
 ```toml
 [dependencies]
-searchlight = "0.3.0"
+searchlight = "0.3.1"
 ```
 
 To learn more about how to use Searchlight, see the [documentation](https://docs.rs/searchlight/).

--- a/src/broadcast/handle.rs
+++ b/src/broadcast/handle.rs
@@ -41,6 +41,7 @@ impl Drop for BroadcasterHandleDrop {
 /// A handle to a [`Broadcaster`](super::Broadcaster) instance that is running in the background.
 ///
 /// You can use this handle to shut down the broadcaster instance remotely, and to add or remove services.
+#[must_use = "The broadcaster instance will shut down if the handle is dropped; store the handle somewhere or use `std::mem::forget` to keep it running"]
 pub struct BroadcasterHandle(pub(super) BroadcasterHandleDrop);
 impl BroadcasterHandle {
 	#[inline(always)]

--- a/src/discovery/handle.rs
+++ b/src/discovery/handle.rs
@@ -35,6 +35,7 @@ impl Drop for DiscoveryHandleDrop {
 /// A handle to a [`Discovery`](super::Discovery) instance that is running in the background.
 ///
 /// You can use this handle to shut down the discovery instance remotely.
+#[must_use = "The discovery instance will shut down if the handle is dropped; store the handle somewhere or use `std::mem::forget` to keep it running"]
 pub struct DiscoveryHandle(pub(super) DiscoveryHandleDrop);
 impl DiscoveryHandle {
 	/// Shuts down the discovery instance if it is still running.

--- a/src/net.rs
+++ b/src/net.rs
@@ -150,12 +150,15 @@ impl MulticastSocketEx<Ipv4Addr> for tokio::net::UdpSocket {
 	fn set_multicast_if(&self, iface: Ipv4Addr) -> Result<(), std::io::Error> {
 		use std::os::unix::io::AsRawFd;
 		unsafe {
+			let iface = libc::in_addr {
+				s_addr: u32::from(iface).to_be(),
+			};
 			let res = libc::setsockopt(
 				self.as_raw_fd(),
 				libc::IPPROTO_IP,
 				libc::IP_MULTICAST_IF,
-				&u32::from(iface) as *const _ as *const _,
-				std::mem::size_of::<u32>() as libc::socklen_t,
+				&iface as *const _ as *const _,
+				std::mem::size_of::<libc::in_addr>() as libc::socklen_t,
 			);
 			if res == 0 {
 				Ok(())


### PR DESCRIPTION
- Fixes `set_multicast_if` for IPv4 interfaces on UNIX
- Adds `#[must_use]` to `BroadcasterHandle` and `DiscoveryHandle` to warn about drop behaviour
- Bumps version